### PR TITLE
Fix bug in Dockerfile generation

### DIFF
--- a/stacker/assembler.py
+++ b/stacker/assembler.py
@@ -58,10 +58,10 @@ def generate_dockerfile(os: str, framework: str, file_name: str = "Dockerfile"):
     tf_version = dlrs[os]["tensorflow"]["mkl"]["version"]
     hvd_version = dlrs[os]["horovod"]["version"]
     torch_version = dlrs[os]["pytorch"]["mkl"]["version"]
-    pkg_installer = "apt-get install -y" if os == "ubuntu" else "swupd bundle-add -y"
+    pkg_installer = "apt-get install -y" if os == "ubuntu" else "swupd bundle-add"
     kwargs = {
         "os": "{}:{}".format(os, os_version),
-        "pkg_install": "{} {}".format(pkg_installer, ",".join(pkgs)),
+        "pkg_install": "{} {}".format(pkg_installer, " ".join(pkgs)),
         "tf_version": tf_version,
         "hvd_version": hvd_version,
         "torch_version": torch_version,
@@ -76,7 +76,7 @@ def genrate_all_dockerfles(generate: bool = True, build: bool = False) -> None:
     if generate:
         base_dir = "./dockerfiles"
         for framework in ["pytorch", "tensorflow"]:
-            for _os in ["ubuntu", "clear"]:
+            for _os in ["ubuntu", "clearlinux"]:
                 save_to_dir = mkdir_p(os.path.join(base_dir, _os, framework))
                 save_to_file = os.path.join(save_to_dir, "Dockerfile")
                 generate_dockerfile(_os, framework, save_to_file)

--- a/stacker/configs/dlrs.yaml
+++ b/stacker/configs/dlrs.yaml
@@ -28,7 +28,7 @@ stack:
           src:
             url: "github.com/tensorflow/tensorflow.git"
             branch: "r2.1"
-        oss:     
+        oss:
           version: "1.15.0"
           tag: tf_oss
       pytorch:
@@ -40,7 +40,7 @@ stack:
           version: "1.0.0"
       horovod:
         version: "0.16.0"
-    clear:
+    clearlinux:
       version: latest
       release: "dlrs_clear"
       os_pkgs:


### PR DESCRIPTION
This path fixt the bug on a wrong Dockerfile generated with:

FROM:clear

Instead of

FROM:clearlinux

As well the swupd bundle-add does not need -y ( invalid param ) and does
not use , to list bundles to install

Signed-off-by: Victor Rodriguez <victor.rodriguez.bahena@intel.com>